### PR TITLE
UI/custom fields card

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -52,63 +52,6 @@ public class PersonCard extends UiPart<Region> {
     private FlowPane tags;
 
     /**
-    * Hides a node from both view and layout.
-    * <p>Using {@code visible=false} stops rendering; {@code managed=false} removes it from
-    * the parent's layout pass so no empty space is reserved.</p>
-    * @param n node to hide
-    */
-    private void hide(Node n) {
-        n.setManaged(false);
-        n.setVisible(false);
-    }
-
-    /**
-    * Builds a single {@code key : value} row for the custom fields section.
-    * <p>Reuses the small-label style so the row visually matches the rest of the card.</p>
-    * @param key   field name (displayed as {@code key: })
-    * @param value field value text
-    * @return a horizontal row containing the labels
-    */
-    private HBox kvRow(String key, String value) {
-        Label keyLabel = new Label(key + ":");
-        keyLabel.getStyleClass().add("Label");
-
-        Label valueLabel = new Label(" " + value);
-        valueLabel.getStyleClass().add("Label");
-
-        HBox pill = new HBox(4, keyLabel, valueLabel);
-        pill.getStyleClass().add("custom-field-pill");
-
-        return new HBox(pill);
-    }
-
-
-    /**
-    * Attempts to obtain a map of custom fields from {@code person} without creating a compile-time
-    * dependency on model changes.
-    * <p>This uses reflection to call {@code getCustomFields()} if/when it exists. If absent or
-    * incompatible, returns an empty map. This lets the UI ship now and "light up" automatically
-    * later when the model adds the method.</p>
-    * @param person the model object for this card
-    * @return a non-null map of {@code key -> value} pairs (empty if none/unsupported)
-    */
-    @SuppressWarnings("unchecked")
-    private java.util.Map<String, Object> tryGetCustomFields(Object person) {
-        try {
-            var m = person.getClass().getMethod("getCustomFields");
-            Object result = m.invoke(person);
-            if (result instanceof java.util.Map<?, ?> map) {
-                var out = new java.util.LinkedHashMap<String, Object>();
-                map.forEach((k, v) -> { if (k != null) out.put(String.valueOf(k), v); });
-                return out;
-            }
-        } catch (Exception ignored) {
-            // Method not present yet, or not accessible; fall through to empty map.
-        }
-        return java.util.Map.of();
-    }
-
-    /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
      */
     public PersonCard(Person person, int displayedIndex) {
@@ -150,13 +93,73 @@ public class PersonCard extends UiPart<Region> {
         if (customFieldsBox.getChildren().isEmpty()
                && (Boolean.getBoolean("dev.customfields.preview") || System.getenv("CF_PREVIEW") != null)) {
             customFieldsBox.getChildren().addAll(
-            kvRow("asset-class", "gold"),
-            kvRow("company", "Goldman Sachs")
+                kvRow("asset-class", "gold"),
+                kvRow("company", "Goldman Sachs")
             );
         }
 
         if (customFieldsBox.getChildren().isEmpty()) {
             hide(customFieldsBox); // hide LAST
         }
+    }
+
+    /**
+    * Hides a node from both view and layout.
+    * <p>Using {@code visible=false} stops rendering; {@code managed=false} removes it from
+    * the parent's layout pass so no empty space is reserved.</p>
+    * @param n node to hide
+    */
+    private void hide(Node n) {
+        n.setManaged(false);
+        n.setVisible(false);
+    }
+
+    /**
+    * Builds a single {@code key : value} row for the custom fields section.
+    * <p>Reuses the small-label style so the row visually matches the rest of the card.</p>
+    * @param key   field name (displayed as {@code key: })
+    * @param value field value text
+    * @return a horizontal row containing the labels
+    */
+    private HBox kvRow(String key, String value) {
+        Label keyLabel = new Label(key + ":");
+        keyLabel.getStyleClass().add("Label");
+
+        Label valueLabel = new Label(" " + value);
+        valueLabel.getStyleClass().add("Label");
+
+        HBox pill = new HBox(4, keyLabel, valueLabel);
+        pill.getStyleClass().add("custom-field-pill");
+
+        return new HBox(pill);
+    }
+
+    /**
+    * Attempts to obtain a map of custom fields from {@code person} without creating a compile-time
+    * dependency on model changes.
+    * <p>This uses reflection to call {@code getCustomFields()} if/when it exists. If absent or
+    * incompatible, returns an empty map. This lets the UI ship now and "light up" automatically
+    * later when the model adds the method.</p>
+    * @param person the model object for this card
+    * @return a non-null map of {@code key -> value} pairs (empty if none/unsupported)
+    */
+    @SuppressWarnings("unchecked")
+    private java.util.Map<String, Object> tryGetCustomFields(Object person) {
+        try {
+            var m = person.getClass().getMethod("getCustomFields");
+            Object result = m.invoke(person);
+            if (result instanceof java.util.Map<?, ?> map) {
+                var out = new java.util.LinkedHashMap<String, Object>();
+                map.forEach((k, v) -> {
+                    if (k != null) {
+                        out.put(String.valueOf(k), v);
+                    }
+                });
+                return out;
+            }
+        } catch (Exception ignored) {
+            // Method not present yet, or not accessible; fall through to empty map.
+        }
+        return java.util.Map.of();
     }
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -3,10 +3,12 @@ package seedu.address.ui;
 import java.util.Comparator;
 
 import javafx.fxml.FXML;
+import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
 import seedu.address.model.person.Person;
 
 /**
@@ -28,6 +30,14 @@ public class PersonCard extends UiPart<Region> {
 
     @FXML
     private HBox cardPane;
+   
+    /**
+    * Container that hosts zero or more {@code key : value} rows for user-defined (custom) fields.
+    * <p>Hidden when empty so the card layout remains identical to vanilla AB3.</p>
+    */
+    @FXML
+    private VBox customFieldsBox;
+   
     @FXML
     private Label name;
     @FXML
@@ -40,6 +50,63 @@ public class PersonCard extends UiPart<Region> {
     private Label email;
     @FXML
     private FlowPane tags;
+
+    /**
+    * Hides a node from both view and layout.
+    * <p>Using {@code visible=false} stops rendering; {@code managed=false} removes it from
+    * the parent's layout pass so no empty space is reserved.</p>
+    * @param n node to hide
+    */
+    private void hide(Node n) {
+        n.setManaged(false);
+        n.setVisible(false);
+    }
+
+    /**
+    * Builds a single {@code key : value} row for the custom fields section.
+    * <p>Reuses the small-label style so the row visually matches the rest of the card.</p>
+    * @param key   field name (displayed as {@code key: })
+    * @param value field value text
+    * @return a horizontal row containing the labels
+    */
+    private HBox kvRow(String key, String value) {
+        Label keyLabel = new Label(key + ":");
+        keyLabel.getStyleClass().add("Label");
+
+        Label valueLabel = new Label(" " + value);
+        valueLabel.getStyleClass().add("Label");
+        
+        HBox pill = new HBox(4, keyLabel, valueLabel);
+        pill.getStyleClass().add("custom-field-pill");
+
+        return new HBox(pill);
+    }
+
+
+    /**
+    * Attempts to obtain a map of custom fields from {@code person} without creating a compile-time
+    * dependency on model changes.
+    * <p>This uses reflection to call {@code getCustomFields()} if/when it exists. If absent or
+    * incompatible, returns an empty map. This lets the UI ship now and "light up" automatically
+    * later when the model adds the method.</p>
+    * @param person the model object for this card
+    * @return a non-null map of {@code key -> value} pairs (empty if none/unsupported)
+    */
+    @SuppressWarnings("unchecked")
+    private java.util.Map<String, Object> tryGetCustomFields(Object person) {
+        try {
+            var m = person.getClass().getMethod("getCustomFields");
+            Object result = m.invoke(person);
+            if (result instanceof java.util.Map<?, ?> map) {
+                var out = new java.util.LinkedHashMap<String, Object>();
+                map.forEach((k, v) -> { if (k != null) out.put(String.valueOf(k), v); });
+                return out;
+            }
+        } catch (Exception ignored) {
+            // Method not present yet, or not accessible; fall through to empty map.
+        }
+        return java.util.Map.of();
+    }
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -55,5 +122,41 @@ public class PersonCard extends UiPart<Region> {
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+
+        // ----- Custom fields (schema-less key:value) -----
+        // We render arbitrary user-defined attributes as "key : value" rows.
+        // If there are no rows, the entire section is hidden to keep the card compact.
+        // Once Person#getCustomFields() is added on the model, the reflection-based
+        // lookup below will start returning data without additional UI changes.
+        
+        customFieldsBox.getChildren().clear();
+        
+        var fields = tryGetCustomFields(person); // empty for now; real values later
+        
+        // Stable alphabetical order (case-insensitive) so cards are predictable to scan.
+        var keys = new java.util.ArrayList<>(fields.keySet());
+        java.util.Collections.sort(keys, String.CASE_INSENSITIVE_ORDER);
+        for (String key : keys) {
+            Object valObj = fields.get(key);
+            String val = (valObj == null) ? "" : String.valueOf(valObj);
+            if (!val.isBlank()) {
+                customFieldsBox.getChildren().add(kvRow(key, val));
+            }
+        }
+       
+        // DEV PREVIEW:
+        // Launch with: ./gradlew run -Ddev.customfields.preview=true
+        // to visualize two sample rows before the model feature lands.
+        if (customFieldsBox.getChildren().isEmpty() 
+               && (Boolean.getBoolean("dev.customfields.preview") || System.getenv("CF_PREVIEW") != null)) {
+            customFieldsBox.getChildren().addAll(
+            kvRow("asset-class", "gold"),
+            kvRow("company", "Goldman Sachs")
+            );
+        }
+        
+        if (customFieldsBox.getChildren().isEmpty()) {
+            hide(customFieldsBox); // hide LAST
+        }
     }
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -30,14 +30,14 @@ public class PersonCard extends UiPart<Region> {
 
     @FXML
     private HBox cardPane;
-   
+
     /**
     * Container that hosts zero or more {@code key : value} rows for user-defined (custom) fields.
     * <p>Hidden when empty so the card layout remains identical to vanilla AB3.</p>
     */
     @FXML
     private VBox customFieldsBox;
-   
+
     @FXML
     private Label name;
     @FXML
@@ -75,7 +75,7 @@ public class PersonCard extends UiPart<Region> {
 
         Label valueLabel = new Label(" " + value);
         valueLabel.getStyleClass().add("Label");
-        
+
         HBox pill = new HBox(4, keyLabel, valueLabel);
         pill.getStyleClass().add("custom-field-pill");
 
@@ -128,11 +128,11 @@ public class PersonCard extends UiPart<Region> {
         // If there are no rows, the entire section is hidden to keep the card compact.
         // Once Person#getCustomFields() is added on the model, the reflection-based
         // lookup below will start returning data without additional UI changes.
-        
+
         customFieldsBox.getChildren().clear();
-        
+
         var fields = tryGetCustomFields(person); // empty for now; real values later
-        
+
         // Stable alphabetical order (case-insensitive) so cards are predictable to scan.
         var keys = new java.util.ArrayList<>(fields.keySet());
         java.util.Collections.sort(keys, String.CASE_INSENSITIVE_ORDER);
@@ -143,18 +143,18 @@ public class PersonCard extends UiPart<Region> {
                 customFieldsBox.getChildren().add(kvRow(key, val));
             }
         }
-       
+
         // DEV PREVIEW:
         // Launch with: ./gradlew run -Ddev.customfields.preview=true
         // to visualize two sample rows before the model feature lands.
-        if (customFieldsBox.getChildren().isEmpty() 
+        if (customFieldsBox.getChildren().isEmpty()
                && (Boolean.getBoolean("dev.customfields.preview") || System.getenv("CF_PREVIEW") != null)) {
             customFieldsBox.getChildren().addAll(
             kvRow("asset-class", "gold"),
             kvRow("company", "Goldman Sachs")
             );
         }
-        
+
         if (customFieldsBox.getChildren().isEmpty()) {
             hide(customFieldsBox); // hide LAST
         }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -348,5 +348,24 @@
     -fx-padding: 1 3 1 3;
     -fx-border-radius: 2;
     -fx-background-radius: 2;
-    -fx-font-size: 11;
+    -fx-font-size: 11px;
 }
+
+/* Chip style for custom-field values (same as #tags .label) */
+.custom-field-pill {
+    -fx-text-fill: white;
+    -fx-background-color: #7f74d9;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+}
+
+.custom-field-pill .label {
+    -fx-text-fill: white;
+    -fx-font-size: 11px;
+}
+
+
+
+
+

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -28,6 +28,12 @@
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
       <FlowPane fx:id="tags" />
+      <!-- Custom fields (generic key:value rows) -->
+      <VBox fx:id="customFieldsBox" spacing="3">
+        <VBox.margin>
+          <Insets top="3"/>
+        </VBox.margin>
+      </VBox>
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />


### PR DESCRIPTION
**What**
1. Add custom-field pills to _`PersonCard`_ (schema-less `key: value` pairs).
2. Pills match tag chip sizing; section hides when empty (no layout gaps).
3. Optional local preview so UI can be verified before model/parser lands. [_Preview_ with: `CF_PREVIEW=1 ./gradlew run`
(No need to touch hide() — preview rows are added before the hide check.)_]

**Why**
1. UI compiles now; it will auto-render real data once _`Person#getCustomFields()`_ is added.
2. Supports the user story for customizable fields per contact.

**How reviewers can verify**
1. With preview on, each card shows two sample pills: asset-class: gold, company: Goldman Sachs.
2. With preview off (default), the custom-fields section is hidden.

Tag chips remain unchanged.

Closes: #50

<img width="740" height="598" alt="v1 2 UI mockup" src="https://github.com/user-attachments/assets/09038e72-f79e-4995-a69b-a0f5bf370f3f" />
