### PR TITLE
UI/custom fields card

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -3,10 +3,12 @@ package seedu.address.ui;
 import java.util.Comparator;
 
 import javafx.fxml.FXML;
+import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
 import seedu.address.model.person.Person;
 
 /**
@@ -28,6 +30,14 @@ public class PersonCard extends UiPart<Region> {
 
     @FXML
     private HBox cardPane;
+
+    /**
+    * Container that hosts zero or more {@code key : value} rows for user-defined (custom) fields.
+    * <p>Hidden when empty so the card layout remains identical to vanilla AB3.</p>
+    */
+    @FXML
+    private VBox customFieldsBox;
+
     @FXML
     private Label name;
     @FXML
@@ -55,5 +65,101 @@ public class PersonCard extends UiPart<Region> {
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+
+        // ----- Custom fields (schema-less key:value) -----
+        // We render arbitrary user-defined attributes as "key : value" rows.
+        // If there are no rows, the entire section is hidden to keep the card compact.
+        // Once Person#getCustomFields() is added on the model, the reflection-based
+        // lookup below will start returning data without additional UI changes.
+
+        customFieldsBox.getChildren().clear();
+
+        var fields = tryGetCustomFields(person); // empty for now; real values later
+
+        // Stable alphabetical order (case-insensitive) so cards are predictable to scan.
+        var keys = new java.util.ArrayList<>(fields.keySet());
+        java.util.Collections.sort(keys, String.CASE_INSENSITIVE_ORDER);
+        for (String key : keys) {
+            Object valObj = fields.get(key);
+            String val = (valObj == null) ? "" : String.valueOf(valObj);
+            if (!val.isBlank()) {
+                customFieldsBox.getChildren().add(kvRow(key, val));
+            }
+        }
+
+        // DEV PREVIEW:
+        // Launch with: ./gradlew run -Ddev.customfields.preview=true
+        // to visualize two sample rows before the model feature lands.
+        if (customFieldsBox.getChildren().isEmpty()
+               && (Boolean.getBoolean("dev.customfields.preview") || System.getenv("CF_PREVIEW") != null)) {
+            customFieldsBox.getChildren().addAll(
+                kvRow("asset-class", "gold"),
+                kvRow("company", "Goldman Sachs")
+            );
+        }
+
+        if (customFieldsBox.getChildren().isEmpty()) {
+            hide(customFieldsBox); // hide LAST
+        }
+    }
+
+    /**
+    * Hides a node from both view and layout.
+    * <p>Using {@code visible=false} stops rendering; {@code managed=false} removes it from
+    * the parent's layout pass so no empty space is reserved.</p>
+    * @param n node to hide
+    */
+    private void hide(Node n) {
+        n.setManaged(false);
+        n.setVisible(false);
+    }
+
+    /**
+    * Builds a single {@code key : value} row for the custom fields section.
+    * <p>Reuses the small-label style so the row visually matches the rest of the card.</p>
+    * @param key   field name (displayed as {@code key: })
+    * @param value field value text
+    * @return a horizontal row containing the labels
+    */
+    private HBox kvRow(String key, String value) {
+        Label keyLabel = new Label(key + ":");
+        keyLabel.getStyleClass().add("Label");
+
+        Label valueLabel = new Label(" " + value);
+        valueLabel.getStyleClass().add("Label");
+
+        HBox pill = new HBox(4, keyLabel, valueLabel);
+        pill.getStyleClass().add("custom-field-pill");
+
+        return new HBox(pill);
+    }
+
+    /**
+    * Attempts to obtain a map of custom fields from {@code person} without creating a compile-time
+    * dependency on model changes.
+    * <p>This uses reflection to call {@code getCustomFields()} if/when it exists. If absent or
+    * incompatible, returns an empty map. This lets the UI ship now and "light up" automatically
+    * later when the model adds the method.</p>
+    * @param person the model object for this card
+    * @return a non-null map of {@code key -> value} pairs (empty if none/unsupported)
+    */
+    @SuppressWarnings("unchecked")
+    private java.util.Map<String, Object> tryGetCustomFields(Object person) {
+        try {
+            var m = person.getClass().getMethod("getCustomFields");
+            Object result = m.invoke(person);
+            if (result instanceof java.util.Map<?, ?> map) {
+                var out = new java.util.LinkedHashMap<String, Object>();
+                map.forEach((k, v) -> {
+                    if (k != null) {
+                        out.put(String.valueOf(k), v);
+                    }
+                });
+                return out;
+            }
+        } catch (Exception ignored) {
+            // Method not present yet, or not accessible; fall through to empty map.
+        }
+        return java.util.Map.of();
     }
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -348,5 +348,24 @@
     -fx-padding: 1 3 1 3;
     -fx-border-radius: 2;
     -fx-background-radius: 2;
-    -fx-font-size: 11;
+    -fx-font-size: 11px;
 }
+
+/* Chip style for custom-field values (same as #tags .label) */
+.custom-field-pill {
+    -fx-text-fill: white;
+    -fx-background-color: #7f74d9;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+}
+
+.custom-field-pill .label {
+    -fx-text-fill: white;
+    -fx-font-size: 11px;
+}
+
+
+
+
+

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -28,6 +28,12 @@
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
       <FlowPane fx:id="tags" />
+      <!-- Custom fields (generic key:value rows) -->
+      <VBox fx:id="customFieldsBox" spacing="3">
+        <VBox.margin>
+          <Insets top="3"/>
+        </VBox.margin>
+      </VBox>
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />

--- a/src/test/java/seedu/address/ui/PersonCardPreviewTest.java
+++ b/src/test/java/seedu/address/ui/PersonCardPreviewTest.java
@@ -1,0 +1,182 @@
+package seedu.address.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javafx.application.Platform;
+import javafx.scene.Parent;
+import javafx.scene.layout.VBox;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Headless UI test that turns on the preview flag and verifies pills render.
+ */
+public class PersonCardPreviewTest {
+
+    private static final Person DUMMY_PERSON = new Person(
+            new Name("Preview Person"),
+            new Phone("99999999"),
+            new Email("preview@example.com"),
+            new Address("123 Preview Street"),
+            new HashSet<Tag>());
+
+    private String prevPreview;
+
+    @BeforeAll
+    static void bootFx() throws Exception {
+        String os = System.getProperty("os.name", "").toLowerCase();
+
+        try {
+            if (os.contains("linux")) {
+                // Headless JavaFX for CI
+                System.setProperty("java.awt.headless", "true");
+                System.setProperty("glass.platform", "Monocle");
+                System.setProperty("monocle.platform", "Headless");
+                System.setProperty("prism.order", "sw"); // software rendering
+                System.setProperty("prism.text", "t2k");
+                System.setProperty("prism.lcdtext", "false");
+
+                if (!Platform.isFxApplicationThread()) {
+                    final java.util.concurrent.CountDownLatch started =
+                            new java.util.concurrent.CountDownLatch(1);
+                    try {
+                        Platform.startup(started::countDown); // ← headless FX startup
+                    } catch (IllegalStateException already) {
+                        // FX already started — fine
+                        started.countDown();
+                    }
+                    if (!started.await(10, java.util.concurrent.TimeUnit.SECONDS)) {
+                        org.junit.jupiter.api.Assumptions.assumeTrue(
+                                false, "Skip: JavaFX startup timed out on this runner");
+                    }
+                }
+            } else {
+                // macOS/Windows: easiest and reliable — initializes JavaFX toolkit via AWT
+                new javafx.embed.swing.JFXPanel();
+            }
+        } catch (Throwable t) {
+            // If anything goes wrong, SKIP the test so CI doesn’t fail on environment issues
+            org.junit.jupiter.api.Assumptions.assumeTrue(false,
+                "Skip: cannot initialize JavaFX in this environment: " + t);
+        }
+    }
+
+    @AfterEach
+    void restorePreviewFlag() {
+        if (prevPreview == null) {
+            System.clearProperty("dev.customfields.preview");
+        } else {
+            System.setProperty("dev.customfields.preview", prevPreview);
+        }
+    }
+
+    @Test
+    void personCard_previewOn_customFieldsVisible() throws Exception {
+        prevPreview = System.setProperty("dev.customfields.preview", "true");
+
+        final CountDownLatch built = new CountDownLatch(1);
+        final Parent[] rootRef = new Parent[1];
+
+        Platform.runLater(() -> {
+            PersonCard card = new PersonCard(DUMMY_PERSON, 1);
+            rootRef[0] = card.getRoot();
+            built.countDown();
+        });
+
+        assertTrue(built.await(5, TimeUnit.SECONDS), "FX init timed out");
+        Parent root = rootRef[0];
+        assertNotNull(root, "PersonCard root should not be null");
+
+        VBox box = (VBox) root.lookup("#customFieldsBox");
+        assertNotNull(box, "customFieldsBox should exist");
+        assertTrue(box.isVisible(), "customFieldsBox should be visible when preview is enabled");
+        assertFalse(box.getChildren().isEmpty(), "preview should add at least one pill");
+    }
+
+    @Test
+    void personCard_noFields_hidesBox() throws Exception {
+        prevPreview = System.setProperty("dev.customfields.preview", "false");
+
+        final CountDownLatch built = new CountDownLatch(1);
+        final Parent[] rootRef = new Parent[1];
+
+        Platform.runLater(() -> {
+            PersonCard card = new PersonCard(DUMMY_PERSON, 1);
+            rootRef[0] = card.getRoot();
+            built.countDown();
+        });
+
+        assertTrue(built.await(5, TimeUnit.SECONDS), "FX init timed out");
+        VBox box = (VBox) rootRef[0].lookup("#customFieldsBox");
+        assertNotNull(box, "customFieldsBox should exist");
+        assertFalse(box.isVisible(), "When no fields, box should be hidden (visible=false)");
+        assertFalse(box.isManaged(), "When hidden, box should be unmanaged (managed=false)");
+    }
+
+    @Test
+    void personCard_previewOff_reflectionAddsSortedRows() throws Exception {
+        prevPreview = System.setProperty("dev.customfields.preview", "false");
+
+        // Subclass adds the method that the UI looks up via reflection
+        Person personWithFields = new Person(
+                new Name("With Fields"),
+                new Phone("11111111"),
+                new Email("with@fields.com"),
+                new Address("1 Field St"),
+                new HashSet<Tag>()) {
+
+            @SuppressWarnings("unused")
+            public java.util.Map<String, Object> getCustomFields() {
+                java.util.Map<String, Object> m = new java.util.LinkedHashMap<>();
+                m.put("company", "Goldman Sachs");
+                m.put("asset-class", "gold");
+                m.put(null, "ignored"); // null key should be ignored by tryGetCustomFields
+                return m;
+            }
+        };
+
+        final CountDownLatch built = new CountDownLatch(1);
+        final Parent[] rootRef = new Parent[1];
+
+        Platform.runLater(() -> {
+            PersonCard card = new PersonCard(personWithFields, 1);
+            rootRef[0] = card.getRoot();
+            built.countDown();
+        });
+
+        assertTrue(built.await(5, TimeUnit.SECONDS), "FX init timed out");
+        VBox box = (VBox) rootRef[0].lookup("#customFieldsBox");
+        assertNotNull(box, "customFieldsBox should exist");
+
+        // Box should be visible and have two rows (company, asset-class) added via kvRow(...)
+        assertTrue(box.isVisible(), "Box should be visible when fields exist");
+        assertFalse(box.getChildren().isEmpty(), "Rows should have been added");
+
+        // Verify stable alphabetical order (case-insensitive): "asset-class" then "company"
+        // Each child is the HBox returned by kvRow(...) (outer HBox containing the 'pill' HBox)
+        javafx.scene.layout.HBox row0 = (javafx.scene.layout.HBox) box.getChildren().get(0);
+        javafx.scene.layout.HBox pill0 = (javafx.scene.layout.HBox) row0.getChildren().get(0);
+        String key0 = ((javafx.scene.control.Label) pill0.getChildren().get(0)).getText(); // "asset-class:"
+        assertTrue(key0.toLowerCase().startsWith("asset-class"));
+
+        javafx.scene.layout.HBox row1 = (javafx.scene.layout.HBox) box.getChildren().get(1);
+        javafx.scene.layout.HBox pill1 = (javafx.scene.layout.HBox) row1.getChildren().get(0);
+        String key1 = ((javafx.scene.control.Label) pill1.getChildren().get(0)).getText(); // "company:"
+        assertTrue(key1.toLowerCase().startsWith("company"));
+    }
+}
+


### PR DESCRIPTION
## What
1. Add **custom-field pills** to `PersonCard` (schema-less `key: value` pairs).
2. Pills **match tag chip sizing**; section **hides when empty** (no layout gaps).
3. Include an **optional local preview** so UI can be verified before model/parser lands.

## Why
- Supports the user story for **customizable fields per contact**.
- UI compiles now and will **auto-render real data** once `Person#getCustomFields()` is added.

## How to preview locally (no model needed)
> Preview rows are added **before** the hide check, so there’s **no need to modify code**.

**Option A (recommended):**
```bash
CF_PREVIEW=1 ./gradlew run
```
<img width="740" height="598" alt="v1 2 UI mockup" src="https://github.com/user-attachments/assets/ee303b4b-b259-4972-a152-2231579a7c5a" />

Closes #50 