### PR TITLE
Add custom-fields logic + storage + tests

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FieldCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FieldCommand.java
@@ -1,0 +1,121 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.grammars.command.Command;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Adds or updates custom key→value fields on a person.
+ * Usage: {@code field <index> /<key>:<value> ...}
+ */
+public class FieldCommand {
+
+    private final int oneBasedIndex;
+    private final Map<String, String> pairs;
+
+    /**
+     * Creates a FieldCommand from a parsed {@link Command}.
+     * @throws IllegalArgumentException if parameters/options are invalid.
+     */
+    public FieldCommand(Command c) {
+        requireNonNull(c);
+        if (!"field".equalsIgnoreCase(c.getImperative())) {
+            throw new IllegalArgumentException("Wrong imperative for FieldCommand");
+        }
+        // Parse index (1-based)
+        try {
+            this.oneBasedIndex = Integer.parseInt(c.getParameter(0));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Missing or invalid index. Usage: field <index> /key:value ...");
+        }
+        // Collect /key:value options
+        Map<String, String> tmp = new LinkedHashMap<>();
+        for (var e : c.getAllOptions().entrySet()) {
+            String k = e.getKey();
+            String v = e.getValue();
+            if (v != null) {
+                tmp.put(k, v);
+            }
+        }
+        if (tmp.isEmpty()) {
+            throw new IllegalArgumentException(
+                "Provide at least one /key:value pair. Usage: field <index> /key:value ...");
+        }
+        this.pairs = tmp;
+    }
+
+    /**
+     * Convenience constructor used by tests.
+     */
+    public FieldCommand(int oneBasedIndex, Map<String, String> pairs) {
+        if (oneBasedIndex <= 0 || pairs == null || pairs.isEmpty()) {
+            throw new IllegalArgumentException("Index must be > 0 and at least one /key:value pair provided.");
+        }
+        this.oneBasedIndex = oneBasedIndex;
+        this.pairs = new LinkedHashMap<>(pairs);
+    }
+
+    /**
+     * Executes the command: updates the selected person's custom fields and returns a user message.
+     */
+    public String execute(Model model) {
+        requireNonNull(model);
+        var list = model.getFilteredPersonList();
+        int zero = oneBasedIndex - 1;
+        if (zero < 0 || zero >= list.size()) {
+            throw new IllegalArgumentException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+        Person target = list.get(zero);
+
+        // Merge strategy: overwrite existing keys with new values, keep others.
+        Map<String, String> merged = new LinkedHashMap<>(target.getCustomFields());
+        for (Map.Entry<String, String> e : pairs.entrySet()) {
+            String k = normalizeKey(e.getKey());
+            String v = normalizeValue(e.getValue());
+            validate(k, v);
+            merged.put(k, v);
+        }
+
+        Person edited = target.withCustomFields(merged);
+        model.setPerson(target, edited);
+        // persistence handled by LogicManager or caller
+
+        // Build feedback message
+        StringBuilder sb = new StringBuilder("Added/updated field(s): ");
+        boolean first = true;
+        for (Map.Entry<String, String> e : pairs.entrySet()) {
+            if (!first) {
+                sb.append(", ");
+            }
+            first = false;
+            sb.append(e.getKey()).append(":").append(e.getValue());
+        }
+        sb.append(" for ").append(edited.getName().fullName);
+        return sb.toString();
+    }
+
+    private static String normalizeKey(String key) {
+        return key == null ? "" : key.trim();
+    }
+
+    private static String normalizeValue(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private static void validate(String key, String value) {
+        if (key.isEmpty()) {
+            throw new IllegalArgumentException("Field name cannot be blank.");
+        }
+        if (value.isEmpty()) {
+            throw new IllegalArgumentException("Field value cannot be blank.");
+        }
+        // Optional: add length constraints if CheckStyle/enforcer requires.
+    }
+}
+

--- a/src/main/java/seedu/address/logic/grammars/command/Command.java
+++ b/src/main/java/seedu/address/logic/grammars/command/Command.java
@@ -110,4 +110,12 @@ public class Command {
     public boolean hasOption(String key) {
         return this.options.containsKey(key);
     }
+
+    /*
+     * Returns a read-only view of all option key→value pairs.
+     */
+    public java.util.Map<String, String> getAllOptions() {
+        return java.util.Collections.unmodifiableMap(this.options);
+    }
+
 }

--- a/src/main/java/seedu/address/logic/grammars/command/lexer/CommandLexer.java
+++ b/src/main/java/seedu/address/logic/grammars/command/lexer/CommandLexer.java
@@ -43,7 +43,11 @@ public class CommandLexer {
     }
 
     private static boolean isCharacterOfWord(char c) {
-        return ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') || ('0' <= c && c <= '9');
+        return ('A' <= c && c <= 'Z')
+               || ('a' <= c && c <= 'z')
+               || ('0' <= c && c <= '9')
+               || c == '-'
+               || c == '_';
     }
 
     private static boolean isRestrictedCharacter(char c) {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -4,6 +4,8 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -24,6 +26,7 @@ public class Person {
     // Data fields
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
+    private final Map<String, String> customFields;
 
     /**
      * Every field must be present and not null.
@@ -35,6 +38,23 @@ public class Person {
         this.email = email;
         this.address = address;
         this.tags.addAll(tags);
+        this.customFields = new LinkedHashMap<>(); //default: empty
+    }
+
+    /**
+     * Full constructor including custom fields.
+     * Kept package-private to encourage creation via {@link #withCustomFields(Map)}
+     */
+    public Person(Name name, Phone phone, Email email, Address address,
+                  Set<Tag> tags, Map<String, String> customFields) {
+        requireAllNonNull(name, phone, email, address, tags);
+        this.name = name;
+        this.phone = phone;
+        this.email = email;
+        this.address = address;
+        this.tags.addAll(tags);
+        // Preserve order and make defensive copy
+        this.customFields = new LinkedHashMap<>(customFields);
     }
 
     public Name getName() {
@@ -59,6 +79,21 @@ public class Person {
      */
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
+    }
+
+    /**
+     * Returns an unmodifiable view of custom fields.
+     */
+    public Map<String, String> getCustomFields() {
+        return Collections.unmodifiableMap(customFields);
+    }
+
+    /**
+     * Returns a new {@code Person} identical to this, but with the provided custom fields.
+     * The provided map is copied defensively and iteration order is preserved.
+     */
+    public Person withCustomFields(Map<String, String> fields) {
+        return new Person(name, phone, email, address, tags, new LinkedHashMap<>(fields));
     }
 
     /**
@@ -94,13 +129,14 @@ public class Person {
                 && phone.equals(otherPerson.phone)
                 && email.equals(otherPerson.email)
                 && address.equals(otherPerson.address)
-                && tags.equals(otherPerson.tags);
+                && tags.equals(otherPerson.tags)
+                && customFields.equals(otherPerson.customFields);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags);
+        return Objects.hash(name, phone, email, address, tags, customFields);
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -2,7 +2,9 @@ package seedu.address.storage;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -29,6 +31,7 @@ class JsonAdaptedPerson {
     private final String email;
     private final String address;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
+    private final Map<String, String> customFields = new LinkedHashMap<>();
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
@@ -57,6 +60,7 @@ class JsonAdaptedPerson {
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
+        customFields.putAll(source.getCustomFields()); // preserve order
     }
 
     /**
@@ -103,7 +107,8 @@ class JsonAdaptedPerson {
         final Address modelAddress = new Address(address);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags);
+        // Backward compatible: if customFields missing, LinkedHashMap stays empty.
+        Person base = new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags);
+        return base.withCustomFields(customFields);
     }
-
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -81,8 +81,8 @@ public class PersonCard extends UiPart<Region> {
 
         customFieldsBox.getChildren().clear();
 
-        // In preview mode we show deterministic example fields; otherwise none.
-        Map<String, String> fields = getPreviewCustomFieldsIfEnabled();
+        // Real Data
+        Map<String, String> fields = new java.util.LinkedHashMap<>(person.getCustomFields());
 
         // Stable alphabetical order (case-insensitive) sp cards are predictable to scan.
         var keys = new java.util.ArrayList<>(fields.keySet());

--- a/src/test/java/seedu/address/logic/commands/FieldCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FieldCommandTest.java
@@ -1,0 +1,79 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.grammars.command.Command;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+class FieldCommandTest {
+
+    private Model model;
+
+    @BeforeEach
+    void setup() {
+        model = new ModelManager(new AddressBook(), new UserPrefs());
+        // Add one person so index 1 is valid
+        Person base = new PersonBuilder().withName("Alex Yeoh").build();
+        model.addPerson(base);
+    }
+
+    @Test
+    void execute_singlePair_success() throws Exception {
+        Command gc = Command.parse("field 1 /company:\"Goldman Sachs\"");
+        FieldCommand cmd = new FieldCommand(gc);
+
+        String feedback = cmd.execute(model);
+
+        assertTrue(feedback.contains("company:Goldman Sachs"));
+        Person edited = model.getFilteredPersonList().get(0);
+        assertEquals("Goldman Sachs", edited.getCustomFields().get("company"));
+    }
+
+    @Test
+    void execute_multiplePairs_overwriteAndOrder() throws Exception {
+        Command gc = Command.parse("field 1 /asset-class:gold /company:\"Goldman Sachs\" /company:GS");
+        FieldCommand cmd = new FieldCommand(gc);
+        cmd.execute(model);
+
+        Person edited = model.getFilteredPersonList().get(0);
+        // last write wins
+        assertEquals("GS", edited.getCustomFields().get("company"));
+        // order preserved
+        assertArrayEquals(new String[]{"asset-class", "company"},
+                edited.getCustomFields().keySet().toArray(new String[0]));
+    }
+
+    @Test
+    void constructor_fromGrammar_invalidIndex_throws() throws Exception {
+        Command gc = Command.parse("field x /k:v");
+        assertThrows(IllegalArgumentException.class, () -> new FieldCommand(gc));
+    }
+
+    @Test
+    void constructor_fromGrammar_noPairs_throws() throws Exception {
+        Command gc = Command.parse("field 1"); // no /k:v
+        assertThrows(IllegalArgumentException.class, () -> new FieldCommand(gc));
+    }
+
+    @Test
+    void execute_indexOutOfBounds_throws() throws Exception {
+        // There is only 1 person in the model
+        Command gc = Command.parse("field 2 /k:v");
+        FieldCommand cmd = new FieldCommand(gc);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> cmd.execute(model));
+        assertEquals(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, ex.getMessage());
+    }
+}
+

--- a/src/test/java/seedu/address/logic/grammars/command/CommandOptionsAccessorTest.java
+++ b/src/test/java/seedu/address/logic/grammars/command/CommandOptionsAccessorTest.java
@@ -1,0 +1,20 @@
+package seedu.address.logic.grammars.command;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class CommandOptionsAccessorTest {
+
+    @Test
+    void getAllOptions_containsDashedKey_unmodifiable() throws Exception {
+        Command c = Command.parse("field 1 /asset-class:gold /company:GS");
+        Map<String,String> opts = c.getAllOptions();
+
+        assertEquals("gold", opts.get("asset-class"));
+        assertThrows(UnsupportedOperationException.class, () -> opts.put("x","y"));
+    }
+}
+

--- a/src/test/java/seedu/address/logic/grammars/command/lexer/CommandLexerHyphenTest.java
+++ b/src/test/java/seedu/address/logic/grammars/command/lexer/CommandLexerHyphenTest.java
@@ -1,0 +1,23 @@
+package seedu.address.logic.grammars.command.lexer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.grammars.command.Command;
+
+class CommandLexerHyphenTest {
+
+    @Test
+    void dashedOptionName_supported() throws Exception {
+        Command c = Command.parse("field 1 /asset-class:gold");
+        assertEquals("gold", c.getOptionValue("asset-class"));
+    }
+
+    @Test
+    void spacesAroundColon_allowed() throws Exception {
+        Command c = Command.parse("field 1 /asset-class : gold");
+        assertEquals("gold", c.getOptionValue("asset-class"));
+    }
+}
+

--- a/src/test/java/seedu/address/model/person/PersonCustomFieldsTest.java
+++ b/src/test/java/seedu/address/model/person/PersonCustomFieldsTest.java
@@ -1,0 +1,50 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+class PersonCustomFieldsTest {
+
+    @Test
+    void getCustomFields_unmodifiable() {
+        Person p = new PersonBuilder().build();
+        assertThrows(UnsupportedOperationException.class, () ->
+                p.getCustomFields().put("k", "v"));
+    }
+
+    @Test
+    void withCustomFields_copiesAndPreservesOrder() {
+        Person p = new PersonBuilder().build();
+        Map<String,String> in = new LinkedHashMap<>();
+        in.put("asset-class", "gold");
+        in.put("company", "GS");
+
+        Person q = p.withCustomFields(in);
+        // different instance
+        assertNotSame(p, q);
+        // order preserved
+        assertArrayEquals(new String[]{"asset-class", "company"},
+                q.getCustomFields().keySet().toArray(new String[0]));
+        // defensive copy
+        in.put("x", "y");
+        assertFalse(q.getCustomFields().containsKey("x"));
+    }
+
+    @Test
+    void equalsAndHashCode_includeCustomFields() {
+        Person a = new PersonBuilder().withName("Alex").build();
+        Person b = new PersonBuilder().withName("Alex").build();
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+
+        Person c = a.withCustomFields(Map.of("company", "GS"));
+        assertNotEquals(a, c);
+    }
+}
+

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonCustomFieldsTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonCustomFieldsTest.java
@@ -1,0 +1,42 @@
+package seedu.address.storage;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+class JsonAdaptedPersonCustomFieldsTest {
+
+    @TempDir Path temp;
+
+    @Test
+    void roundTrip_preservesCustomFieldsAndOrder() throws Exception {
+        AddressBook book = new AddressBook();
+        Map<String,String> cf = new LinkedHashMap<>();
+        cf.put("asset-class", "gold");
+        cf.put("company", "GS");
+
+        Person p = new PersonBuilder().withName("Alex").build().withCustomFields(cf);
+        book.addPerson(p);
+
+        Path file = temp.resolve("ab.json");
+        JsonAddressBookStorage storage = new JsonAddressBookStorage(file);
+        storage.saveAddressBook(book);
+        ReadOnlyAddressBook loaded = storage.readAddressBook(file).get();
+
+        Person loadedP = loaded.getPersonList().get(0);
+        assertEquals(cf, loadedP.getCustomFields());
+        assertArrayEquals(cf.keySet().toArray(), loadedP.getCustomFields().keySet().toArray());
+    }
+}
+


### PR DESCRIPTION
### Summary
Add **custom fields** support to contacts and the command to set them.  
Users can attach arbitrary `key:value` pairs (e.g., `asset-class: gold`, `company: Goldman Sachs`) that render as chips on each `PersonCard`. Visual styling/layout remains unchanged.

---

### User-facing changes
- _field `index` /`key`:`value`_

Examples:
- `field 1 /asset-class:gold /company:"Goldman Sachs"`
- `field 2 /rating:A /account-id:12345`
- **Keys with hyphens** are supported (e.g., `/asset-class:gold`).
- **Optional spaces** around `:` are accepted (e.g., `/asset-class : gold`).

---

### Scope of changes
**Logic**
- `FieldCommand` parses/validates pairs and updates the selected person.

**Model**
- `Person` holds `customFields: Map<String,String>` (insertion-ordered).
- Added `withCustomFields(...)`, `getCustomFields()`, and updated `equals/hashCode`.

**UI**
- `PersonCard` now renders from `person.getCustomFields()` (no visual changes).

**Grammar**
- Lexer allows hyphens in option names and tolerates spaces around `:`.
- Added `Command#getAllOptions()` to iterate `/key:value` pairs.

---

### Error handling
- Invalid/missing `<index>` → `MESSAGE_INVALID_PERSON_DISPLAYED_INDEX`.
- No `/key:value` pairs → usage error.
- Blank key or value → validation error.

---

### How to verify locally
```bash
./gradlew clean run
# In the app:
# field 1 /asset-class:gold /company:"Goldman Sachs"
```
---

Closes #51 