### PR TITLE
Update ParserClass.puml

### DIFF
--- a/docs/diagrams/add-remark/ParserClass.puml
+++ b/docs/diagrams/add-remark/ParserClass.puml
@@ -6,9 +6,9 @@ Class "<<interface>>\nParser" as Parser
 Class RemarkCommandParser {
   +parse(): RemarkCommand
 }
-Class ParserException
+Class RemarkParserException
 
 RemarkCommandParser .up.|> Parser
-Parser .right.> ParserException: throws >
-RemarkCommandParser .right.> ParserException: throws >
+Parser .right.> RemarkParserException: throws >
+RemarkCommandParser .right.> RemarkParserException: throws >
 @enduml


### PR DESCRIPTION
Renamed the parser exception class in the add-remark UML diagram to RemarkParserException and updated related relationship references to use the new name.