### PR TITLE
Update UndoRedoState0.puml

### DIFF
--- a/docs/diagrams/UndoRedoState0.puml
+++ b/docs/diagrams/UndoRedoState0.puml
@@ -18,4 +18,7 @@ hide State3
 
 class Pointer as "Current State" #FFFFFF
 Pointer -up-> State1
+note right of Pointer
+    Indicates the head of the undo history.
+end note
 @end


### PR DESCRIPTION
Added a clarifying note to the initial undo/redo state diagram to explain the current state pointer’s role in the history.