### PR TITLE
Clarify command parameter handling in User Guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -176,6 +176,8 @@ Shows a list of all persons in the address book.
 
 Format: `list`
 
+* Although the documented format shows no parameters, the parser accepts any additional text after the command word. Inputs such as `list 123` are treated the same as `list` and open the help window without error.
+
 ### Viewing command history : `history`
 
 Displays the list of commands previously entered.
@@ -192,6 +194,10 @@ Examples:
   2. list
   3. delete 2
   ```
+
+_Additional notes:_
+
+* Although the documented format shows no parameters, the parser accepts any additional text after the command word. Inputs such as `history 123` are treated the same as `history` and open the help window without error.
 
 ### Editing a person : `edit`
 
@@ -402,6 +408,8 @@ _Additional notes:_
 Clears all entries from the address book.
 
 Format: `clear`
+
+* Any extra words typed after `clear` are ignored. For instance, `clear now` will still clear the entries from the address book.
 
 ### Exiting the program : `exit`
 


### PR DESCRIPTION
Closes #213.

Update the User Guide to explain how the list, history, and clear commands handle additional parameters, ensuring users understand that extra inputs do not cause errors.