### PR TITLE
Remove unnecessary restriction blocking specific special characters

### DIFF
--- a/src/main/java/seedu/address/logic/grammars/command/lexer/CommandLexer.java
+++ b/src/main/java/seedu/address/logic/grammars/command/lexer/CommandLexer.java
@@ -53,7 +53,7 @@ public class CommandLexer {
     }
 
     private static boolean isRestrictedCharacter(char c) {
-        return c == '/' || c == ':' || c == '\"';
+        return c == '\"';
     }
 
     /**

--- a/src/test/java/seedu/address/logic/grammars/command/lexer/CommandLexerTest.java
+++ b/src/test/java/seedu/address/logic/grammars/command/lexer/CommandLexerTest.java
@@ -94,11 +94,4 @@ public class CommandLexerTest {
 
         assertThrows(LexerException.class, () -> CommandLexer.lexCommand(ingest));
     }
-
-    @Test
-    public void lex_illegalCharacterInString_throwsException() {
-        String ingest = "event create /description:\"online quiz\" /from:\"2025-09-20:1000\" /to:\"2025-09-20 1100\"";
-
-        assertThrows(LexerException.class, () -> CommandLexer.lexCommand(ingest));
-    }
 }


### PR DESCRIPTION
The command lexer previously did not conform to UG specifications allowing any special character to be escaped by quotes. This patch fixes the errant production rule that causes this behaviour.

The following production rule is the source of this error:
> `<text> ::= "[^"\/:]*"`

This has been relaxed to
>  `<text> ::= "[^"]*"`
